### PR TITLE
Bump minimum required versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "product-recommendations-custom-locations",
 	"title": "Product Recommendations - Custom Locations",
-	"version": "1.0.3",
+	"version": "2.0.0",
 	"homepage": "https://woocommerce.com/products/product-recommendations/",
 	"repository": {
 		"type": "git",

--- a/product-recommendations-custom-locations.php
+++ b/product-recommendations-custom-locations.php
@@ -3,20 +3,20 @@
 * Plugin Name: Product Recommendations - Custom Locations
 * Plugin URI: https://woocommerce.com/products/product-recommendations/
 * Description: Use shortcodes and blocks to display product recommendations in custom pages and locations. Free feature plugin for the official WooCommerce Product Recommendations extension.
-* Version: 1.0.3
+* Version: 2.0.0
 * Author: SomewhereWarm
 * Author URI: https://somewherewarm.com/
 *
 * Text Domain: woocommerce-product-recommendations-custom-locations
 * Domain Path: /languages/
 *
-* Requires at least: 4.4
-* Tested up to: 6.3
+* Requires at least: 6.2
+* Tested up to: 6.6
 *
-* WC requires at least: 3.3
-* WC tested up to: 8.0
+* WC requires at least: 8.2
+* WC tested up to: 9.1
 *
-* Copyright: © 2017-2021 SomewhereWarm SMPC.
+* Copyright: © 2017-2024 SomewhereWarm SMPC.
 * License: GNU General Public License v3.0
 * License URI: http://www.gnu.org/licenses/gpl-3.0.html
 */
@@ -30,7 +30,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Main plugin class.
  *
  * @class    WC_Product_Recommendations_Custom_Locations
- * @version  1.0.3
+ * @version  2.0.0
  */
 class WC_Product_Recommendations_Custom_Locations {
 
@@ -39,14 +39,14 @@ class WC_Product_Recommendations_Custom_Locations {
 	 *
 	 * @var string
 	 */
-	private $version = '1.0.3';
+	private $version = '2.0.0';
 
 	/**
 	 * Min required PRL version.
 	 *
 	 * @var string
 	 */
-	private $prl_min_version = '1.4.12';
+	private $prl_min_version = '4.0';
 
 	/**
 	 * The single instance of the class.

--- a/readme.txt
+++ b/readme.txt
@@ -2,12 +2,12 @@
 
 Contributors: SomewhereWarm
 Tags: woocommerce, product, recommendations, toolkit, tracking, conversion, up-sells, cross-sells
-Requires PHP: 5.6
-Requires at least: 4.4
-Tested up to: 6.3
-Stable tag: 1.0.3
-WC requires at least: 3.3
-WC tested up to: 8.0
+Requires PHP: 7.4
+Requires at least: 6.2
+Tested up to: 6.6
+Stable tag: 2.0.0
+WC requires at least: 8.2
+WC tested up to: 9.1
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -43,6 +43,12 @@ This plugin requires the latest version of the official [WooCommerce Product Rec
 
 
 == Changelog ==
+
+= 2.0.0 =
+* Important - New: PHP 7.4+ is now required.
+* Important - New: WooCommerce 8.2+ is now required.
+* Important - New: WordPress 6.2+ is now required.
+* Important - New: Product Recommendations 4.0+ is now required.
 
 = 1.0.3 =
 * Feature - Declared compatibility with the new High-Performance order tables.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Product Recommendations - Custom Locations ===
 
-Contributors: SomewhereWarm
+Contributors: automattic, woocommerce, SomewhereWarm
 Tags: woocommerce, recommendations, conversion, up-sells, cross-sells
 Requires PHP: 7.4
 Requires at least: 6.2

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Product Recommendations - Custom Locations ===
 
 Contributors: SomewhereWarm
-Tags: woocommerce, product, recommendations, toolkit, tracking, conversion, up-sells, cross-sells
+Tags: woocommerce, recommendations, conversion, up-sells, cross-sells
 Requires PHP: 7.4
 Requires at least: 6.2
 Tested up to: 6.6


### PR DESCRIPTION
### Description

This PR bumps the minimum required:
- PHP version to 7.4,
- WordPress version to 6.2, 
- WooCommerce version to 8.2 and;
- Product Recommendations version to 4.