### PR TITLE
Update empty state button styling

### DIFF
--- a/assets/sass/admin/wc-prl-cl-admin.scss
+++ b/assets/sass/admin/wc-prl-cl-admin.scss
@@ -9,7 +9,7 @@
 	line-height: 1;
 	font-style: normal;
 	font-weight: normal;
-	color: #eee2ec;
+	color: #e9ebeb;
 	top: 50%;
 	transform: translateY( -50% );
 	right: 20px;

--- a/includes/class-wc-prl-cl-post-types.php
+++ b/includes/class-wc-prl-cl-post-types.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Registers custom post types and taxonomies.
  *
  * @class    WC_PRL_CL_Post_Types
- * @version  1.0.0
+ * @version  x.x.x
  */
 class WC_PRL_CL_Post_Types {
 

--- a/includes/class-wc-prl-cl-post-types.php
+++ b/includes/class-wc-prl-cl-post-types.php
@@ -106,7 +106,7 @@ class WC_PRL_CL_Post_Types {
 				<br/>
 				<?php esc_html_e( 'Start by creating a Custom Location, and then use its shortcode anywhere.', 'woocommerce-product-recommendations-custom-locations' ); ?>
 			</p>
-			<a class="button sw-button-primary sw-button-primary--woo" id="sw-button-primary" href="<?php echo admin_url( 'post-new.php?post_type=prl_hook' ); ?>"><?php esc_html_e( 'Add Location', 'woocommerce-product-recommendations-custom-locations' ); ?></a>
+			<a class="components-button is-primary" id="sw-button-primary" href="<?php echo admin_url( 'post-new.php?post_type=prl_hook' ); ?>"><?php esc_html_e( 'Add Location', 'woocommerce-product-recommendations-custom-locations' ); ?></a>
 		</div><?php
 		$message = ob_get_clean();
 		return $message;

--- a/readme.txt
+++ b/readme.txt
@@ -44,6 +44,9 @@ This plugin requires the latest version of the official [WooCommerce Product Rec
 
 == Changelog ==
 
+= x.x.x =
+* Tweak - Updating styling of empty state.
+
 = 2.0.1 =
 * Fix - Include built CSS and JS files.
 


### PR DESCRIPTION
The recently updated the empty state button styling in Product Recommendations:

- https://github.com/woocommerce/woocommerce-product-recommendations/pull/601

This PR makes the same update in this plugin, so that the styling is the same.

**Before (with above change in Product Recommendations):**

<img width="1115" alt="Screenshot 2024-09-03 at 13 57 31" src="https://github.com/user-attachments/assets/2c139d3d-7674-4fd8-ac5b-df6df572d2b9">

**After:**

<img width="1115" alt="Screenshot 2024-09-03 at 13 54 34" src="https://github.com/user-attachments/assets/57822509-6211-4f5c-9d57-e4727f3d1a4c">
