### PR TITLE
Remove Navigation-related code

### DIFF
--- a/includes/admin/class-wc-prl-cl-admin-menus.php
+++ b/includes/admin/class-wc-prl-cl-admin-menus.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Setup PRL menus in WP admin.
  *
- * @version 1.0.1
+ * @version x.x.x
  */
 class WC_PRL_CL_Admin_Menus {
 

--- a/includes/admin/class-wc-prl-cl-admin-menus.php
+++ b/includes/admin/class-wc-prl-cl-admin-menus.php
@@ -11,9 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\WooCommerce\Admin\Features\Navigation\Menu;
-use Automattic\WooCommerce\Admin\Features\Navigation\Screen;
-
 /**
  * Setup PRL menus in WP admin.
  *
@@ -39,9 +36,6 @@ class WC_PRL_CL_Admin_Menus {
 
 		// Integrate WooCommerce breadcrumb bar.
 		add_action( 'admin_menu', array( __CLASS__, 'wc_admin_connect_gc_pages' ) );
-
-		// Integrate WooCommerce side navigation.
-		add_action( 'admin_menu', array( __CLASS__, 'register_navigation_pages' ) );
 	}
 
 	/**
@@ -117,43 +111,6 @@ class WC_PRL_CL_Admin_Menus {
 		}
 
 		return $current_tab;
-	}
-
-	/**
-	 * Register WooCommerce menu pages.
-	 *
-	 * @since  1.0.1
-	 *
-	 * @return void
-	 */
-	public static function register_navigation_pages() {
-
-		if ( ! class_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Menu' ) || ! class_exists( '\Automattic\WooCommerce\Admin\Features\Navigation\Screen' ) ) {
-			return;
-		}
-
-		$match_expression = isset( $_GET[ 'post' ] ) && get_post_type( intval( $_GET[ 'post' ] ) ) === 'prl_hook'
-			? '(edit.php|post.php)'
-			: null;
-		if ( is_null( $match_expression ) ) {
-			$match_expression = isset( $_GET[ 'post_type' ] ) && $_GET[ 'post_type' ] === 'prl_hook'
-			? '(post-new.php)'
-			: null;
-		}
-
-		Menu::add_plugin_item(
-			array(
-				'id'              => 'prl-custom-locations',
-				'title'           => __( 'Custom Locations', 'woocommerce-product-recommendations' ),
-				'capability'      => 'manage_woocommerce',
-				'url'             => 'edit.php?post_type=prl_hook',
-				'parent'          => 'prl-recommendations-category',
-				'matchExpression' => $match_expression,
-				'order'           => 40
-			)
-		);
-
-		Screen::register_post_type( 'prl_hook' );
 	}
 }
 

--- a/readme.txt
+++ b/readme.txt
@@ -45,7 +45,7 @@ This plugin requires the latest version of the official [WooCommerce Product Rec
 == Changelog ==
 
 = x.x.x =
-* Tweak - Remove Navigation-related code.
+* Tweak - Removed navigation integration (deprecated WooCommerce feature).
 
 = 2.0.2 =
 * Tweak - Updating styling of empty state.

--- a/readme.txt
+++ b/readme.txt
@@ -44,6 +44,9 @@ This plugin requires the latest version of the official [WooCommerce Product Rec
 
 == Changelog ==
 
+= x.x.x =
+* Tweak - Remove Navigation-related code.
+
 = 2.0.2 =
 * Tweak - Updating styling of empty state.
 


### PR DESCRIPTION
This PR removes the WC Core Navigation-related code, as that feature has been removed from Core with no replacement.

Closes #15

## Testing instructions

1. Check WP debug log and verify that no deprecation warnings are present (note: other plugins, such as Subscriptions, could have these as well, so deactivate other plugins to be sure):

```
Automattic\WooCommerce\Admin\Features\Navigation\Menu::add_plugin_item is deprecated since 9.3 with no alternative. Navigation classes will be removed in WooCommerce 9.4
Automattic\WooCommerce\Admin\Features\Navigation\Screen::register_post_type is deprecated since 9.3 with no alternative. Navigation classes will be removed in WooCommerce 9.4
```

2. Make sure Custom Locations tab still loads.